### PR TITLE
Added tag manager, adjusted analytics tracking & conditional

### DIFF
--- a/lib/candidate_website/templates/layout/app.html.eex
+++ b/lib/candidate_website/templates/layout/app.html.eex
@@ -35,6 +35,27 @@
 
     <%= {:safe, css_link_tag() } %>
     <link href="https://fonts.googleapis.com/css?family=Montserrat|Roboto+Condensed" rel="stylesheet">
+
+    <%= if assigns[:google_tag_manager_id] != nil do %>
+        <!-- Google Tag Manager -->
+        <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+        new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+        j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        })(window,document,'script','dataLayer','<%= assigns[:google_tag_manager_id] %>');</script>
+        <!-- End Google Tag Manager -->
+    <% end %>
+    <%= if assigns[:google_analytics_id] != nil and assigns[:google_tag_manager_id] == nil do %>
+        <!-- Global Site Tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=<%= assigns[:google_analytics_id] %>"></script>
+        <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments)};
+        gtag('js', new Date());
+
+        gtag('config', '<%= assigns[:google_analytics_id] %>');
+        </script>
+    <% end %>
   </head>
 
   <body>
@@ -61,16 +82,4 @@
   <script>
     flexibility(document.documentElement);
   </script>
-
-  <%= if assigns[:google_analytics_id] != nil do %>
-    <!-- Global Site Tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=GA_TRACKING_ID"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments)};
-      gtag('js', new Date());
-
-      gtag('config', '<%= assigns[:google_analytics_id] %>');
-    </script>
-  <% end %>
 </html>

--- a/lib/require_plug.ex
+++ b/lib/require_plug.ex
@@ -16,6 +16,7 @@ defmodule CandidateWebsite.RequirePlug do
   @optional ~w(
     animation_fill_level target_html hero_text_color before_for_congress
     why_support_picture instagram google_analytics_id linkedin hide_lets
+    google_tag_manager_id
   )
 
   @about_attrs ~w(


### PR DESCRIPTION
Made a couple of minor adjustments to site-side tracking:

- Re-positioned gtag.js calls from body to head, fixed minor error in tracking URL (was calling GA_TRACKING_ID)
- Added Google Tag Manager to the head. 
- Conditional load will fire Tag Manager's tracking JS if :google_tag_manager_id is present, will load Google Analytics as normal if it is not.
- Added google_tag_manager_id as optional field to be pulled from CosmicJS & included in context 
enumerable.