### PR TITLE
Move images from Imgur to Cosmic, optimize size

### DIFF
--- a/lib/candidate_website/templates/page/about-experience-v2.html.eex
+++ b/lib/candidate_website/templates/page/about-experience-v2.html.eex
@@ -1,7 +1,7 @@
 <div id="issues-container-v2">
   <div id="issues-image-container">
     <!-- <img id="issues-image" src="https://cosmic-s3.imgix.net/af464f60-5a34-11e8-a6ea-1773a2afd5cd-alex-2.png"/> -->
-    <img id="issues-image" src="https://i.imgur.com/I05dCKQ.jpg"/>
+    <img id="issues-image" src="https://cosmic-s3.imgix.net/09ed9cc0-8203-11e8-9ec0-a39094ccdb86-I05dCKQ.jpg"/>
   </div>
   <div id="issues-text-container">
     <div id="issues-header-container">

--- a/lib/candidate_website/templates/page/about-moving-forward-v2.html.eex
+++ b/lib/candidate_website/templates/page/about-moving-forward-v2.html.eex
@@ -15,6 +15,6 @@
     </div> -->
   </div>
   <div id="why-support-image">
-    <img id="why-support-image-actual" src="https://i.imgur.com/ZsIujw4.png"/>
+    <img id="why-support-image-actual" src="https://cosmic-s3.imgix.net/80962870-8202-11e8-8ae4-250d9c13bec7-ZsIujw4%20(1).jpg"/>
   </div>
 </div>

--- a/lib/candidate_website/templates/page/chunk-issues-v2.html.eex
+++ b/lib/candidate_website/templates/page/chunk-issues-v2.html.eex
@@ -1,7 +1,7 @@
 <div id="issues-container-v2">
   <div id="issues-image-container">
     <!-- <img id="issues-image" src="https://cosmic-s3.imgix.net/af464f60-5a34-11e8-a6ea-1773a2afd5cd-alex-2.png"/> -->
-    <img id="issues-image" src="https://i.imgur.com/I05dCKQ.jpg"/>
+    <img id="issues-image" src="https://cosmic-s3.imgix.net/09ed9cc0-8203-11e8-9ec0-a39094ccdb86-I05dCKQ.jpg"/>
   </div>
   <div id="issues-text-container">
     <div id="issues-header-container">

--- a/lib/candidate_website/templates/page/chunk-why.html.eex
+++ b/lib/candidate_website/templates/page/chunk-why.html.eex
@@ -15,6 +15,6 @@
     </div>
   </div>
   <div id="why-support-image">
-    <img id="why-support-image-actual" src="https://i.imgur.com/ZsIujw4.png"/>
+    <img id="why-support-image-actual" src="https://cosmic-s3.imgix.net/80962870-8202-11e8-8ae4-250d9c13bec7-ZsIujw4%20(1).jpg"/>
   </div>
 </div>


### PR DESCRIPTION
Replacing these 1.7MB and 3.7MB hotlinked images with smaller ones.